### PR TITLE
fix(control-tower): fix control tower setup

### DIFF
--- a/templates/control-tower.yaml
+++ b/templates/control-tower.yaml
@@ -94,6 +94,13 @@ Resources:
 
               await page.goto(consoleLoginUrl, {waitUntil: ['load', 'networkidle0']});
 
+              // remove cookie banner if present
+              try {
+                page.waitForSelector('#awsccc-cb-buttons > button.awsccc-u-btn.awsccc-u-btn-primary');
+                await page.click('#awsccc-cb-buttons > button.awsccc-u-btn.awsccc-u-btn-primary');
+                await page.waitFor(1000);
+              } catch (e) {
+              }
             });
 
             await synthetics.executeStep('gotoCT', async function () {


### PR DESCRIPTION
by accepting the cookie banner if present. otherwise button would be overlapped by the cookie banner so pupeteers fails clicking through the setup process

@davmayd @troy-ameigh this is a hotfix to adjust to recent UI changes. 

Screenshot of the green pipeline attached:

![image](https://user-images.githubusercontent.com/219372/109347207-142d0900-7873-11eb-8360-b32cebeea770.png)

![image](https://user-images.githubusercontent.com/219372/109347282-33c43180-7873-11eb-8abd-889a82797d17.png)
