### PR TITLE
fix(control-tower): upgrade to latest CW Synthetics version

### DIFF
--- a/templates/control-tower.yaml
+++ b/templates/control-tower.yaml
@@ -40,7 +40,7 @@ Resources:
       Name: superwerker-ct-setup
       ArtifactS3Location: !Sub s3://${SetupControlTowerArtifactLocation}
       ExecutionRoleArn: !GetAtt SetupControlTowerCanaryRole.Arn
-      RuntimeVersion: syn-1.0
+      RuntimeVersion: syn-nodejs-puppeteer-3.1
       StartCanaryAfterCreation: true
       RunConfig:
         TimeoutInSeconds: 600
@@ -336,7 +336,7 @@ Resources:
       Name: superwerker-ct-bug-wa
       ArtifactS3Location: !Sub s3://${SetupControlTowerArtifactLocation}
       ExecutionRoleArn: !GetAtt SetupControlTowerCanaryRole.Arn
-      RuntimeVersion: syn-1.0
+      RuntimeVersion: syn-nodejs-puppeteer-3.1
       StartCanaryAfterCreation: false
       RunConfig:
         TimeoutInSeconds: 300


### PR DESCRIPTION
in order to prevent the deprecated canary version from failing, it won't work anymore from the end of May on.

@davmayd @troy-ameigh please take a look and merge, possibly before May 28th because the `syn-1.0` Canary runtime will stop working then.

Pipeline is green:
![image](https://user-images.githubusercontent.com/219372/118447451-12941400-b6f1-11eb-8d96-01aa4b8bbdc9.png)

